### PR TITLE
drop nodejs 0.8 for testing; upgrade temp,async,cheerio,blanket dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 
 node_js:
- - "0.8"
  - "0.10"
 
 before_install: sudo apt-get install libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+v0.0.6:
+	* drop 0.8 testing; upgrade temp,async,cheerio,blanket dependencies
+
 v0.0.5:
 	* SVG reported creates a badge of coverage (awesome @espadrine!)
 	* fix issue #3 - simultaneous invocation of multiple reporters

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "node": ">=0.8.0"
   },
   "dependencies": {
-    "blanket": "~1.1.5",
-    "temp": "~0.6.0",
-    "async": "~0.2.9",
-    "cheerio": "~0.12.4",
+    "async": "0.9.0",
+    "blanket": "1.1.6",
+    "temp": "0.8.1",
+    "cheerio": "0.14.0",
     "gh-badges": "~0.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
These are changes I had tested before. There is an incompatiblity above cheerio 0.14.0, which is why it is not upgraded to latest.

@dannycoates r?
